### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,5 +1,7 @@
 # アクション名
 name: Build and Test
+permissions:
+  contents: read
 
 # タイミングを指定
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/riya-amemiya/links/security/code-scanning/4](https://github.com/riya-amemiya/links/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the workflow or specific jobs. Since the workflow does not require write access to repository contents or other elevated permissions, we can set `contents: read` as the minimal permission for all jobs. This ensures the workflow operates securely while adhering to the principle of least privilege.

The `permissions` block should be added at the root level of the workflow to apply to all jobs. Alternatively, it can be added to individual jobs if different permissions are required for specific jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
