### PR TITLE
ci: skip build job for dependabot PRs

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -92,6 +92,7 @@ jobs:
     build:
           name: JavaScript Build on Ubuntu
           needs: setup
+          if: github.actor != 'dependabot[bot]'
           runs-on: ${{ matrix.os }}
           strategy:
               matrix:


### PR DESCRIPTION
## Summary

Dependabot PRからはGitHubのセキュリティ制約によりリポジトリのsecretsにアクセスできません。buildジョブは`MICROCMS_SERVICEDOMAIN`と`MICROCMS_API_KEY`のsecretsが必要なため、全てのDependabot PRでビルドが失敗する状態でした。

Dependabotは依存関係の更新のみを行うため、lint・testジョブで十分に検証できます。buildジョブに`if: github.actor != 'dependabot[bot]'`条件を追加し、Dependabot PRではスキップするようにしました。

これにより、#113 のようなDependabot PRが正常にCIを通過できるようになります。

## Test plan

- このPRのCI（lint, test, build）が全て通ることを確認
- このPRマージ後に #113 をrebaseし、CI（lint, test）が通ることを確認

https://claude.ai/code/session_01EBW9CXJ54SJAG2oWiBGiEt