### PR TITLE
Add Cloud Agent development environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,18 @@
+{
+  "name": "links (Next.js + Bun)",
+  "user": "ubuntu",
+  "install": "bash .cursor/install.sh",
+  "terminals": [
+    {
+      "name": "dev",
+      "command": "export PATH=\"$HOME/.bun/bin:$PATH\"; bun run dev",
+      "description": "Next.js dev server on http://localhost:3000 (bun run dev)"
+    }
+  ],
+  "ports": [
+    {
+      "name": "next-dev",
+      "port": 3000
+    }
+  ]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Idempotent Cloud Agent install script for the `links` site.
+# Runs after the repository is checked out. Safe to run repeatedly.
+set -euo pipefail
+
+# Pin Bun to the version declared in devbox.json.
+BUN_VERSION="1.3.6"
+export BUN_INSTALL="${HOME}/.bun"
+export PATH="${BUN_INSTALL}/bin:${PATH}"
+
+# Install the pinned Bun toolchain when it is missing or the wrong version.
+if ! command -v bun >/dev/null 2>&1 || [ "$(bun --version 2>/dev/null || true)" != "${BUN_VERSION}" ]; then
+  curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}"
+fi
+
+# Expose Bun on the default PATH so `start`/`terminals` (non-login shells) find it.
+if command -v sudo >/dev/null 2>&1; then
+  sudo ln -sf "${BUN_INSTALL}/bin/bun" /usr/local/bin/bun
+  sudo ln -sf "${BUN_INSTALL}/bin/bunx" /usr/local/bin/bunx
+fi
+
+# Install JS dependencies from the committed lockfile.
+bun install
+
+# NEXT_PUBLIC_URL is the public canonical site URL (not a secret). It is only
+# required for production builds/serve (build, start, e2e); the dev server falls
+# back to http://localhost:3000. Seed a local .env once without clobbering edits.
+if [ ! -f .env ]; then
+  echo "NEXT_PUBLIC_URL=https://riya-amemiya-links.tokidux.com" > .env
+fi
+
+echo "Install complete: $(bun --version), node $(node --version)"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **repository-managed** Cloud Agent development environment for this Next.js 16 + Bun site, so future agents boot into a ready-to-work setup. Config is versioned with the code and follows branches/PRs (it takes precedence over any dashboard config once merged).

### Files

- `.cursor/environment.json` — declares the environment: idempotent `install`, a `dev` terminal (`bun run dev` on port 3000), and exposes port 3000. Uses Cursor's default base image (no snapshot pinned, so it stays reproducible without personal snapshot IDs).
- `.cursor/install.sh` — installs pinned Bun `1.3.6` (matching `devbox.json`), symlinks it onto the default `PATH`, runs `bun install` from the committed lockfile, and seeds a local `.env` with the public canonical `NEXT_PUBLIC_URL` (gitignored, non-secret) required by production build/serve.

### Design notes

- The default base image already ships Node 22 (compatible with Next.js 16), Google Chrome (required by the Vitest browser + Playwright `channel: "chrome"` tests), `git`, and `curl` — so no custom Dockerfile is needed.
- `install` is idempotent (verified running twice with no changes) and terminates; the dev server lives in `terminals` so it never blocks install.
- `NEXT_PUBLIC_URL` is only required when `NODE_ENV=production` (build/start/e2e); the dev server falls back to `http://localhost:3000`.

### Validation — local VM

| Check | Result |
| --- | --- |
| `bun install` | 1361 packages, idempotent on 2nd run |
| `bun run lint` (ESLint + Biome) | Passed, 62 files |
| `bun run build` (Next.js) | Passed, 16 routes generated |
| `bun run test` (Vitest browser/Chrome) | 3/3 passed, no type errors |
| `bun run test:e2e` (Playwright/Chrome) | 8/8 passed |
| Dev server `/`, `/home`, `/works` | HTTP 200, correct `<title>` |
| End-to-end GUI walkthrough | boot → home → works → stage briefing all render/navigate |

### Validation — fresh Cloud Agent build

Triggered a draft build off this branch using the default base image + committed `install.sh` (build `bld-20260811-8ff6fe92` **SUCCEEDED**), then booted a fresh Cloud Agent from that exact build:

| Check | Result |
| --- | --- |
| Bun / Node / Chrome | `bun 1.3.6`, `node v22`, `google-chrome-stable` present |
| Dependencies (no reinstall) + `.env` | 852+ `node_modules` entries, `NEXT_PUBLIC_URL` set |
| `bun run lint` | Passed |
| `bun run build` | Passed, 16 routes |
| `bun run test` (Vitest/Chrome) | 3/3 passed, no type errors |
| Dev server `/`, `/home`, `/works` | HTTP 200 |

Once merged to `main`, Cloud Agents on this repo pick up this environment automatically.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9d524fb4-6cd6-466a-952f-7ce295d96595?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9d524fb4-6cd6-466a-952f-7ce295d96595&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

